### PR TITLE
Forward non-dynamic messages as safe in the bridge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: rust:1.48.0
+      - image: rust:1.52.0
     environment:
       RUSTFLAGS: -D warnings
     steps:

--- a/witchcraft-log/Cargo.toml
+++ b/witchcraft-log/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witchcraft-log"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/witchcraft-log/src/test.rs
+++ b/witchcraft-log/src/test.rs
@@ -158,4 +158,17 @@ fn bridge() {
         &[("message", Value::String("foobar 123".to_string()))],
     );
     assert_eq!(records[0].error, None);
+
+    log::info!("fizzbuzz");
+    let records = get_records();
+    assert_eq!(records.len(), 1);
+
+    assert_eq!(records[0].level, Level::Info);
+    assert_eq!(records[0].target, module_path!());
+    assert_eq!(records[0].file.as_ref().unwrap(), file!());
+    assert!(records[0].line.is_some());
+    assert_eq!(records[0].message, "fizzbuzz");
+    assert_eq!(records[0].safe_params, &[]);
+    assert_eq!(records[0].unsafe_params, &[]);
+    assert_eq!(records[0].error, None);
 }


### PR DESCRIPTION
In the bridge mapping from the standard `log` crate to the `witchcraft-log` crate, we have previously had to conservatively assume that the log's message contained unsafe information. However, the new `fmt::Arguments::as_str` API will return a `&'static str` if the message was a string literal. In that case we know it is entirely safe to log and can just set it as the message field! Otherwise, we continue to fall back to adding it as an unsafe param and leaving the message field empty.