### PR TITLE
Add an MDC to witchcraft-log

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: rust:1.52.0
+      - image: rust:1.56.1
     environment:
       RUSTFLAGS: -D warnings
     steps:

--- a/witchcraft-log/Cargo.toml
+++ b/witchcraft-log/Cargo.toml
@@ -2,7 +2,7 @@
 name = "witchcraft-log"
 version = "0.3.1"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 description = "A structured logging facade for Witchcraft servers"
 repository = "https://github.com/palantir/witchcraft-rust-logging"
@@ -10,9 +10,11 @@ categories = ["development-tools::debugging"]
 
 [dependencies]
 conjure-error = "0.7"
+conjure-object = "0.7"
 erased-serde = "0.3"
 lazycell = "1.0"
 log = "0.4"
+once_cell = "1"
 serde = "1.0"
 
 [dev-dependencies]

--- a/witchcraft-log/src/level.rs
+++ b/witchcraft-log/src/level.rs
@@ -118,7 +118,7 @@ impl Level {
 
     /// Returns the standard string name of the level.
     pub fn as_str(self) -> &'static str {
-        &LOG_LEVEL_NAMES[self as usize]
+        LOG_LEVEL_NAMES[self as usize]
     }
 }
 

--- a/witchcraft-log/src/lib.rs
+++ b/witchcraft-log/src/lib.rs
@@ -23,7 +23,7 @@
 //! message, information is included via a separate set of parameters. Parameters are partitioned into "safe" parameters
 //! and "unsafe" parameters. Safety in this context is *not* safety in the traditional Rust sense of memory safety, but
 //! instead safety against information leakage. Safe parameters do not contain any sensitive information about use of a
-//! service, and can be exfiltrated from a specific environment, while unsafe parameters contain sensitive information
+//! service and can be exfiltrated from a specific environment, while unsafe parameters contain sensitive information
 //! that should not leave the environment at all. For example, the amount of memory used to process a request could be
 //! a safe parameter, while information about the user executing the request could be an unsafe parameter.
 //!
@@ -76,6 +76,7 @@ mod level;
 mod logger;
 #[macro_use]
 mod macros;
+pub mod mdc;
 #[doc(hidden)]
 pub mod private;
 mod record;

--- a/witchcraft-log/src/mdc.rs
+++ b/witchcraft-log/src/mdc.rs
@@ -1,0 +1,154 @@
+// Copyright 2021 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//! A Mapped Diagnostic Context (MDC) for Witchcraft loggers.
+//!
+//! An MDC is a thread local map containing extra parameters. Witchcraft logging implementations should include the
+//! contents of the MDC in service logs.
+use conjure_object::Any;
+use once_cell::sync::Lazy;
+use serde::Serialize;
+use std::cell::RefCell;
+use std::collections::{hash_map, HashMap};
+use std::sync::Arc;
+
+static EMPTY: Lazy<Arc<HashMap<&'static str, Any>>> = Lazy::new(|| Arc::new(HashMap::new()));
+
+thread_local! {
+    static MDC: RefCell<Snapshot> = RefCell::new(Snapshot {
+        safe_mdc: EMPTY.clone(),
+        unsafe_mdc: EMPTY.clone(),
+    });
+}
+
+/// Clears the contents of the MDC.
+pub fn clear() {
+    MDC.with(|v| {
+        let mut mdc = v.borrow_mut();
+        // try to preserve capacity if we're the unique owner
+        match Arc::get_mut(&mut mdc.safe_mdc) {
+            Some(safe_mdc) => safe_mdc.clear(),
+            None => mdc.safe_mdc = EMPTY.clone(),
+        }
+        match Arc::get_mut(&mut mdc.unsafe_mdc) {
+            Some(unsafe_mdc) => unsafe_mdc.clear(),
+            None => mdc.unsafe_mdc = EMPTY.clone(),
+        }
+    });
+}
+
+/// Inserts a new safe parameter into the MDC.
+///
+/// # Panics
+///
+/// Panics if the value cannot be serialized into an [`Any`].
+pub fn insert_safe<T>(key: &'static str, value: T)
+where
+    T: Serialize,
+{
+    MDC.with(|v| {
+        Arc::make_mut(&mut v.borrow_mut().safe_mdc)
+            .insert(key, Any::new(value).expect("value failed to serialize"))
+    });
+}
+
+/// Inserts a new unsafe parameter into the MDC.
+///
+/// # Panics
+///
+/// Panics if the value cannot be serialized into an [`Any`].
+pub fn insert_unsafe<T>(key: &'static str, value: T)
+where
+    T: Serialize,
+{
+    MDC.with(|v| {
+        Arc::make_mut(&mut v.borrow_mut().unsafe_mdc)
+            .insert(key, Any::new(value).expect("value failed to serialize"))
+    });
+}
+
+/// Removes the specified safe parameter from the MDC.
+pub fn remove_safe(key: &'static str) {
+    MDC.with(|v| Arc::make_mut(&mut v.borrow_mut().safe_mdc).remove(key));
+}
+
+/// Removes the specified unsafe parameter from the MDC.
+pub fn remove_unsafe(key: &'static str) {
+    MDC.with(|v| Arc::make_mut(&mut v.borrow_mut().unsafe_mdc).remove(key));
+}
+
+/// Takes a snapshot of the MDC.
+pub fn snapshot() -> Snapshot {
+    MDC.with(|v| {
+        let mdc = v.borrow();
+        Snapshot {
+            safe_mdc: mdc.safe_mdc.clone(),
+            unsafe_mdc: mdc.unsafe_mdc.clone(),
+        }
+    })
+}
+
+/// Overwrites the MDC with a snapshot.
+pub fn set(snapshot: Snapshot) {
+    MDC.with(|v| *v.borrow_mut() = snapshot);
+}
+
+/// A portable snapshot of the MDC.
+pub struct Snapshot {
+    safe_mdc: Arc<HashMap<&'static str, Any>>,
+    unsafe_mdc: Arc<HashMap<&'static str, Any>>,
+}
+
+impl Snapshot {
+    /// Returns an iterator over the safe parameters in the snapshot.
+    #[inline]
+    pub fn safe_iter(&self) -> Iter<'_> {
+        Iter {
+            it: self.safe_mdc.iter(),
+        }
+    }
+
+    /// Returns an iterator over the unsafe parameters in the snapshot.
+    #[inline]
+    pub fn unsafe_iter(&self) -> Iter<'_> {
+        Iter {
+            it: self.unsafe_mdc.iter(),
+        }
+    }
+}
+
+/// An iterator over parameters in a snapshot.
+pub struct Iter<'a> {
+    it: hash_map::Iter<'a, &'static str, Any>,
+}
+
+impl<'a> Iterator for Iter<'a> {
+    type Item = (&'static str, &'a Any);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.it.next().map(|(k, v)| (*k, v))
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.it.size_hint()
+    }
+}
+
+impl ExactSizeIterator for Iter<'_> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.it.len()
+    }
+}

--- a/witchcraft-log/src/mdc.rs
+++ b/witchcraft-log/src/mdc.rs
@@ -104,7 +104,7 @@ pub fn set(snapshot: Snapshot) {
     MDC.with(|v| *v.borrow_mut() = snapshot);
 }
 
-/// Swaps the MDC with a snapshot, returning a guard object which will un-swap them with it drops.
+/// Swaps the MDC with a snapshot, returning a guard object which will un-swap them when it drops.
 ///
 /// Changes to the MDC while the guard is live will be reflected in the snapshot when the guard drops.
 pub fn with(snapshot: &mut Snapshot) -> WithGuard<'_> {


### PR DESCRIPTION
Since we track safe and unsafe params separately, the API differs a bit from slf4j's.