### PR TITLE
Add utilities for MDC propagation and scoped edits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,3 @@
 [workspace]
-members = [
-    "witchcraft-log",
-    "witchcraft-metrics",
-]
+resolver = "2"
+members = ["witchcraft-log", "witchcraft-metrics"]

--- a/witchcraft-log/Cargo.toml
+++ b/witchcraft-log/Cargo.toml
@@ -15,6 +15,7 @@ erased-serde = "0.4"
 lazycell = "1.0"
 log = "0.4"
 once_cell = "1"
+pin-project = "1.1.5"
 serde = "1.0"
 
 [dev-dependencies]

--- a/witchcraft-log/Cargo.toml
+++ b/witchcraft-log/Cargo.toml
@@ -19,5 +19,6 @@ pin-project = "1.1.5"
 serde = "1.0"
 
 [dev-dependencies]
-serde_test = "1.0"
+futures-executor = "0.3.30"
 serde-value = "0.7"
+serde_test = "1.0"

--- a/witchcraft-log/src/mdc.rs
+++ b/witchcraft-log/src/mdc.rs
@@ -311,6 +311,7 @@ where
     }
 }
 
+/// Sets the MDC state to the snapshot, resetting it to the state it was previously on drop.
 fn scope_with(snapshot: &mut Snapshot) -> ScopeWith<'_> {
     swap(snapshot);
     ScopeWith { snapshot }

--- a/witchcraft-log/src/test.rs
+++ b/witchcraft-log/src/test.rs
@@ -18,7 +18,7 @@ use serde_value::Value;
 use std::cell::RefCell;
 
 thread_local! {
-    static RECORDS: RefCell<Vec<TestRecord>> = RefCell::new(vec![]);
+    static RECORDS: RefCell<Vec<TestRecord>> = const { RefCell::new(vec![]) };
 }
 
 struct TestLogger;


### PR DESCRIPTION
This adds two utility methods to make MDC use more convenient:

`mdc::bind(future)` creates a wrapped future which maintains MDC state across polls. This is similar to the logic we have in witchcraft-server to maintain the MDC for individual requests: https://github.com/palantir/witchcraft-rust-server/blob/develop/witchcraft-server/src/service/mdc.rs.

`mdc::scope()` returns a guard type which resets the MDC state on drop, making it easier to add MDC parameters in a scoped context.