### PR TITLE
Add witchcraft-env-logger

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
 [workspace]
 resolver = "2"
-members = ["witchcraft-log", "witchcraft-metrics"]
+members = [
+    "witchcraft-log",
+    "witchcraft-logging-api",
+    "witchcraft-metrics",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
-    "witchcraft-log",
+    "witchcraft-log", "witchcraft-log-util",
     "witchcraft-logging-api",
     "witchcraft-metrics",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,9 @@
 [workspace]
 resolver = "2"
 members = [
-    "witchcraft-log", "witchcraft-log-util",
+    "witchcraft-env-logger",
+    "witchcraft-log",
+    "witchcraft-log-util",
     "witchcraft-logging-api",
     "witchcraft-metrics",
 ]

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+WITCHCRAFT_API_VERSION=2.5.0
+
+curl \
+    -Lo witchcraft-log-api/witchcraft-logging-api.json \
+    https://repo1.maven.org/maven2/com/palantir/witchcraft/api/witchcraft-logging-api/$WITCHCRAFT_API_VERSION/witchcraft-logging-api-$WITCHCRAFT_API_VERSION.conjure.json

--- a/witchcraft-env-logger/Cargo.toml
+++ b/witchcraft-env-logger/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "witchcraft-env-logger"
+version = "0.1.0"
+edition = "2024"
+license = "Apache-2.0"
+description = "A simple Witchcraft logger that can be configured with an environment variable"
+repository = "https://github.com/palantir/witchcraft-rust-logging"
+categories = ["development-tools::debugging"]
+
+[dependencies]
+conjure-serde = "4.10.0"
+witchcraft-log = { version = "4.0.0", path = "../witchcraft-log" }
+witchcraft-log-util = { version = "1.0.0", path = "../witchcraft-log-util" }

--- a/witchcraft-env-logger/examples/main.rs
+++ b/witchcraft-env-logger/examples/main.rs
@@ -1,0 +1,13 @@
+use witchcraft_log::{Level, debug, error, info};
+
+fn main() {
+    witchcraft_env_logger::init();
+
+    debug!("this is a debug message");
+    error!("this is printed by default");
+
+    if witchcraft_log::enabled!(Level::Info) {
+        let x = 3 * 4; // expensive computation
+        info!("figured out the answer", safe: { answer: x });
+    }
+}

--- a/witchcraft-env-logger/src/lib.rs
+++ b/witchcraft-env-logger/src/lib.rs
@@ -1,0 +1,131 @@
+// Copyright 2025 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//! A simple Witchcraft logger that can be configured with an environment variable.
+//!
+//! This is similar to the [env_logger](https://docs.rs/env_logger) crate, but using the [`witchcraft_log`] crate
+//! instead of the `log` crate. Configuration of logging levels is the same as `env_logger` except for the additional
+//! `fatal` log level. Regex filters are not supported.
+//!
+//! Logs are written to standard error in the standard Witchcraft `service.1` JSON format.
+//!
+//! # Example
+//!
+//! ```
+//! use witchcraft_log::{debug, error, info, Level};
+//!
+//! witchcraft_env_logger::init();
+//!
+//! debug!("this is a debug message");
+//! error!("this is printed by default");
+//!
+//! if witchcraft_log::enabled!(Level::Info) {
+//!     let x = 3 * 4; // expensive computation
+//!     info!("figured out the answer", safe: { answer: x });
+//! }
+//! ```
+//!
+//! ```not_rust
+//! $ RUST_LOG=error ./main
+//! {"type":"service.1","level":"ERROR","time":"2025-05-26T16:45:59.204677531Z","origin":"main","thread":"main","message":"this is printed by default","safe":true,"params":{"file":"witchcraft-env-logger/examples/main.rs","line":7}}
+//! ```
+//!
+//! ```not_rust
+//! $ RUST_LOG=info ./main
+//! {"type":"service.1","level":"ERROR","time":"2025-05-26T16:46:31.043928664Z","origin":"main","thread":"main","message":"this is printed by default","safe":true,"params":{"file":"witchcraft-env-logger/examples/main.rs","line":7}}
+//! {"type":"service.1","level":"INFO","time":"2025-05-26T16:46:31.043976765Z","origin":"main","thread":"main","message":"figured out the answer","safe":true,"params":{"answer":12,"file":"witchcraft-env-logger/examples/main.rs","line":11}}
+//! ```
+//!
+//! ```not_rust
+//! $ RUST_LOG=main=debug ./main
+//! {"type":"service.1","level":"DEBUG","time":"2025-05-26T16:47:04.831643644Z","origin":"main","thread":"main","message":"this is a debug message","safe":true,"params":{"file":"witchcraft-env-logger/examples/main.rs","line":6}}
+//! {"type":"service.1","level":"ERROR","time":"2025-05-26T16:47:04.831691314Z","origin":"main","thread":"main","message":"this is printed by default","safe":true,"params":{"file":"witchcraft-env-logger/examples/main.rs","line":7}}
+//! {"type":"service.1","level":"INFO","time":"2025-05-26T16:47:04.831720469Z","origin":"main","thread":"main","message":"figured out the answer","safe":true,"params":{"answer":12,"file":"witchcraft-env-logger/examples/main.rs","line":11}}
+//! ```
+#![warn(missing_docs)]
+
+use std::{
+    env,
+    io::{self, Write},
+};
+
+use conjure_serde::json;
+use witchcraft_log::{LevelFilter, Log, Metadata, Record, SetLoggerError};
+use witchcraft_log_util::{filter::Filter, service};
+
+struct Logger {
+    filter: Filter,
+}
+
+impl Log for Logger {
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+        self.filter.enabled(metadata)
+    }
+
+    fn log(&self, record: &Record<'_>) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+
+        let service_log = service::from_record(record);
+        let mut buf = json::to_string(&service_log).unwrap();
+        buf.push('\n');
+        // Using the macro so output is intercepted in tests properly
+        eprint!("{buf}");
+    }
+
+    fn flush(&self) {
+        let _ = io::stderr().flush();
+    }
+}
+
+/// Initializes the global logger, reading configuration from the `RUST_LOG` environment variable.
+///
+/// Returns an error if the logger is already initialized.
+pub fn try_init() -> Result<(), SetLoggerError> {
+    let mut builder = Filter::builder();
+
+    if let Ok(rust_log) = env::var("RUST_LOG") {
+        for directive in rust_log.split(",") {
+            let mut it = directive.splitn(2, "=");
+            let first = it.next().unwrap();
+            let second = it.next();
+
+            match second {
+                Some(level) => {
+                    let Ok(level) = level.parse::<LevelFilter>() else {
+                        continue;
+                    };
+                    builder = builder.target_level(first, level);
+                }
+                None => match first.parse::<LevelFilter>() {
+                    Ok(level) => builder = builder.level(level),
+                    Err(_) => builder = builder.target_level(first, LevelFilter::Trace),
+                },
+            }
+        }
+    }
+
+    let filter = builder.build();
+    let max_level = filter.max_level();
+
+    witchcraft_log::set_boxed_logger(Box::new(Logger { filter }))?;
+    witchcraft_log::set_max_level(max_level);
+
+    Ok(())
+}
+
+/// Like [`try_init()`], but panics if the logger is already initialized.
+pub fn init() {
+    try_init().unwrap();
+}

--- a/witchcraft-log-util/Cargo.toml
+++ b/witchcraft-log-util/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "witchcraft-log-util"
+version = "1.0.0"
+edition = "2024"
+license = "Apache-2.0"
+description = "Utilities for Witchcraft logger implementations"
+repository = "https://github.com/palantir/witchcraft-rust-logging"
+
+[dependencies]
+conjure-error = "4.10.0"
+conjure-object = "4.10.0"
+witchcraft-log = { version = "4.0.0", path = "../witchcraft-log" }
+witchcraft-logging-api = { version = "1.0.0", path = "../witchcraft-logging-api" }

--- a/witchcraft-log-util/Cargo.toml
+++ b/witchcraft-log-util/Cargo.toml
@@ -9,5 +9,6 @@ repository = "https://github.com/palantir/witchcraft-rust-logging"
 [dependencies]
 conjure-error = "4.10.0"
 conjure-object = "4.10.0"
+sequence_trie = "0.3.6"
 witchcraft-log = { version = "4.0.0", path = "../witchcraft-log" }
 witchcraft-logging-api = { version = "1.0.0", path = "../witchcraft-logging-api" }

--- a/witchcraft-log-util/src/filter.rs
+++ b/witchcraft-log-util/src/filter.rs
@@ -1,0 +1,154 @@
+// Copyright 2025 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//! A prefix-based target filter.
+
+use sequence_trie::SequenceTrie;
+use witchcraft_log::{LevelFilter, Metadata};
+
+/// A prefix-based target filter.
+///
+/// The filter is configured with a top-level [`LevelFilter`] and additional per-target filters. Targets are interpreted
+/// as a hierarchy by splitting on `::`. For example a target `foo::bar` will have a filter for the `foo` target
+/// applied to it if there is not also a filter for `foo::bar` itself.
+pub struct Filter {
+    trie: SequenceTrie<String, LevelFilter>,
+}
+
+impl Filter {
+    /// Returns a new builder.
+    #[inline]
+    pub fn builder() -> Builder {
+        Builder {
+            filter: Filter {
+                trie: SequenceTrie::new(),
+            },
+            root: LevelFilter::Error,
+        }
+    }
+
+    /// Determines if the provided log metadata matches the filter.
+    pub fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+        metadata.level()
+            <= *self
+                .trie
+                .get_ancestor(metadata.target().split("::"))
+                .unwrap()
+    }
+
+    /// Returns the most verbose level in the filter.
+    pub fn max_level(&self) -> LevelFilter {
+        self.trie.values().max().copied().unwrap()
+    }
+}
+
+/// A builder for [`Filter`]s.
+pub struct Builder {
+    filter: Filter,
+    root: LevelFilter,
+}
+
+impl Builder {
+    /// Sets the level used for targets that don't match a more specific directive.
+    ///
+    /// Defaults to [`LevelFilter::Error`].
+    #[inline]
+    pub fn level(mut self, level: LevelFilter) -> Self {
+        self.root = level;
+        self
+    }
+
+    /// Sets the level used for a specific target.
+    #[inline]
+    pub fn target_level(mut self, target: &str, level: LevelFilter) -> Self {
+        self.filter.trie.insert(target.split("::"), level);
+        self
+    }
+
+    /// Consumes the builder, returning a filter.
+    #[inline]
+    pub fn build(mut self) -> Filter {
+        self.filter.trie.insert_owned([], self.root);
+        self.filter
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use witchcraft_log::Level;
+
+    use super::*;
+
+    #[test]
+    fn empty() {
+        let filter = Filter::builder().build();
+
+        assert!(
+            filter.enabled(
+                &Metadata::builder()
+                    .level(Level::Error)
+                    .target("foo")
+                    .build()
+            )
+        );
+
+        assert!(!filter.enabled(&Metadata::builder().level(Level::Warn).target("foo").build()));
+    }
+
+    #[test]
+    fn nonempty() {
+        let filter = Filter::builder()
+            .level(LevelFilter::Warn)
+            .target_level("foo", LevelFilter::Debug)
+            .target_level("foo::bar", LevelFilter::Off)
+            .build();
+
+        assert!(
+            filter.enabled(
+                &Metadata::builder()
+                    .level(Level::Error)
+                    .target("bar")
+                    .build()
+            )
+        );
+        assert!(!filter.enabled(&Metadata::builder().level(Level::Info).target("bar").build()));
+
+        assert!(filter.enabled(&Metadata::builder().level(Level::Info).target("foo").build()));
+        assert!(
+            !filter.enabled(
+                &Metadata::builder()
+                    .level(Level::Trace)
+                    .target("foo")
+                    .build()
+            )
+        );
+
+        assert!(
+            !filter.enabled(
+                &Metadata::builder()
+                    .level(Level::Fatal)
+                    .target("foo::bar")
+                    .build()
+            )
+        );
+
+        assert!(
+            filter.enabled(
+                &Metadata::builder()
+                    .level(Level::Fatal)
+                    .target("foo::buz")
+                    .build()
+            )
+        );
+    }
+}

--- a/witchcraft-log-util/src/lib.rs
+++ b/witchcraft-log-util/src/lib.rs
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //! Utilities for Witchcraft logger implementations.
+#![warn(missing_docs)]
 
+pub mod filter;
 pub mod mdc;
-
 pub mod service;

--- a/witchcraft-log-util/src/lib.rs
+++ b/witchcraft-log-util/src/lib.rs
@@ -1,0 +1,18 @@
+// Copyright 2025 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//! Utilities for Witchcraft logger implementations.
+
+pub mod mdc;
+
+pub mod service;

--- a/witchcraft-log-util/src/mdc.rs
+++ b/witchcraft-log-util/src/mdc.rs
@@ -1,0 +1,29 @@
+// Copyright 2025 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//! MDC keys with special behavior.
+
+/// The safe MDC key storing the value for the `uid` field in service logs.
+pub const UID_KEY: &str = "\0witchcraft-uid";
+
+/// The safe MDC key storing the value for the `sid` field in service logs.
+pub const SID_KEY: &str = "\0witchcraft-sid";
+
+/// The safe MDC key storing the value for the `tokenId` field in service logs.
+pub const TOKEN_ID_KEY: &str = "\0witchcraft-token-id";
+
+/// The safe MDC key storing the value for the `orgId` field in service logs.
+pub const ORG_ID_KEY: &str = "\0witchcraft-org-id";
+
+/// The safe MDC key storing the value for the `traceId` field in service logs.
+pub const TRACE_ID_KEY: &str = "\0witchcraft-trace-id";

--- a/witchcraft-log-util/src/service.rs
+++ b/witchcraft-log-util/src/service.rs
@@ -34,7 +34,7 @@ pub fn from_record(record: &Record<'_>) -> ServiceLogV1 {
     };
 
     let mut message = ServiceLogV1::builder()
-        .type_("service.")
+        .type_("service.1")
         .level(level)
         .time(Utc::now())
         .message(record.message())

--- a/witchcraft-log-util/src/service.rs
+++ b/witchcraft-log-util/src/service.rs
@@ -1,0 +1,128 @@
+// Copyright 2025 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//! Utilities for Witchcraft service logs.
+use std::fmt::Write;
+use std::{error, thread};
+
+use conjure_error::ErrorKind;
+use conjure_object::Utc;
+use witchcraft_log::{Level, Record, mdc};
+use witchcraft_logging_api::{
+    LogLevel, OrganizationId, ServiceLogV1, SessionId, TokenId, TraceId, UserId,
+};
+
+/// Serialize a `witchcraft-log` record into a standard `ServiceLogV1` object.
+pub fn from_record(record: &Record<'_>) -> ServiceLogV1 {
+    let level = match record.level() {
+        Level::Fatal => LogLevel::Fatal,
+        Level::Error => LogLevel::Error,
+        Level::Warn => LogLevel::Warn,
+        Level::Info => LogLevel::Info,
+        Level::Debug => LogLevel::Debug,
+        Level::Trace => LogLevel::Trace,
+    };
+
+    let mut message = ServiceLogV1::builder()
+        .type_("service.")
+        .level(level)
+        .time(Utc::now())
+        .message(record.message())
+        .safe(true)
+        .origin(record.target().to_string())
+        .thread(thread::current().name().map(ToString::to_string));
+
+    let mdc = mdc::snapshot();
+    for (key, value) in mdc.safe().iter() {
+        match key {
+            crate::mdc::UID_KEY => {
+                if let Ok(uid) = value.clone().deserialize_into::<UserId>() {
+                    message = message.uid(uid);
+                }
+            }
+            crate::mdc::SID_KEY => {
+                if let Ok(sid) = value.clone().deserialize_into::<SessionId>() {
+                    message = message.sid(sid);
+                }
+            }
+            crate::mdc::TOKEN_ID_KEY => {
+                if let Ok(token_id) = value.clone().deserialize_into::<TokenId>() {
+                    message = message.token_id(token_id);
+                }
+            }
+            crate::mdc::ORG_ID_KEY => {
+                if let Ok(org_id) = value.clone().deserialize_into::<OrganizationId>() {
+                    message = message.org_id(org_id);
+                }
+            }
+            crate::mdc::TRACE_ID_KEY => {
+                if let Ok(trace_id) = value.clone().deserialize_into::<TraceId>() {
+                    message = message.trace_id(trace_id);
+                }
+            }
+            key => message = message.insert_params(key, value),
+        }
+    }
+    message = message.extend_unsafe_params(
+        mdc.unsafe_()
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.clone())),
+    );
+
+    if let Some(file) = record.file() {
+        message = message.insert_params("file", file);
+    }
+    if let Some(line) = record.line() {
+        message = message.insert_params("line", line);
+    }
+    if let Some(error) = record.error() {
+        if let ErrorKind::Service(s) = error.kind() {
+            message = message
+                .insert_params("errorInstanceId", s.error_instance_id())
+                .insert_params("errorCode", s.error_code())
+                .insert_params("errorName", s.error_name());
+        }
+
+        let mut stacktrace = String::new();
+        for trace in error.backtraces() {
+            writeln!(stacktrace, "{:?}", trace).unwrap();
+        }
+        message = message.stacktrace(stacktrace);
+
+        let mut causes = vec![];
+        let mut cause = Some(error.cause() as &dyn error::Error);
+        while let Some(e) = cause {
+            causes.push(e.to_string());
+            cause = e.source();
+        }
+        if error.cause_safe() {
+            message = message.insert_params("errorCause", causes);
+        } else {
+            message = message.insert_unsafe_params("errorCause", causes);
+        }
+        for (key, value) in &error.safe_params() {
+            message = message.insert_params(key, value);
+        }
+        for (key, value) in &error.unsafe_params() {
+            message = message.insert_unsafe_params(key, value);
+        }
+    }
+    for (key, value) in record.safe_params() {
+        message = message.insert_params(*key, value);
+    }
+    for (key, value) in record.unsafe_params() {
+        message = message.insert_unsafe_params(*key, value);
+    }
+
+    message.build()
+}

--- a/witchcraft-log/Cargo.toml
+++ b/witchcraft-log/Cargo.toml
@@ -12,9 +12,7 @@ categories = ["development-tools::debugging"]
 conjure-error = "4"
 conjure-object = "4"
 erased-serde = "0.4"
-lazycell = "1.0"
 log = "0.4"
-once_cell = "1"
 pin-project = "1.1.5"
 serde = "1.0"
 

--- a/witchcraft-log/src/level.rs
+++ b/witchcraft-log/src/level.rs
@@ -247,7 +247,7 @@ impl<'de> Deserialize<'de> for Level {
     {
         struct LevelIdentifier;
 
-        impl<'de> Visitor<'de> for LevelIdentifier {
+        impl Visitor<'_> for LevelIdentifier {
             type Value = Level;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -323,7 +323,7 @@ impl<'de> Deserialize<'de> for LevelFilter {
     {
         struct LevelFilterIdentifier;
 
-        impl<'de> Visitor<'de> for LevelFilterIdentifier {
+        impl Visitor<'_> for LevelFilterIdentifier {
             type Value = LevelFilter;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/witchcraft-logging-api/Cargo.toml
+++ b/witchcraft-logging-api/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "witchcraft-logging-api"
+version = "1.0.0"
+edition = "2024"
+license = "Apache-2.0"
+description = "Witchcraft log API types"
+repository = "https://github.com/palantir/witchcraft-rust-logging"
+
+[build-dependencies]
+conjure-codegen = "4.10.0"
+
+[dependencies]
+conjure-object = "4.10.0"

--- a/witchcraft-logging-api/build.rs
+++ b/witchcraft-logging-api/build.rs
@@ -1,0 +1,27 @@
+// Copyright 2025 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{env, path::PathBuf};
+
+fn main() {
+    let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+
+    conjure_codegen::Config::new()
+        .strip_prefix(Some("com.palantir.witchcraft.api.logging".to_string()))
+        .generate_files(
+            "witchcraft-logging-api.json",
+            out_dir.join("witchcraft-logging-api"),
+        )
+        .unwrap();
+}

--- a/witchcraft-logging-api/src/lib.rs
+++ b/witchcraft-logging-api/src/lib.rs
@@ -1,0 +1,14 @@
+// Copyright 2025 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+include!(concat!(env!("OUT_DIR"), "/witchcraft-logging-api/mod.rs"));

--- a/witchcraft-logging-api/witchcraft-logging-api.json
+++ b/witchcraft-logging-api/witchcraft-logging-api.json
@@ -1,0 +1,2774 @@
+{
+  "version" : 1,
+  "errors" : [ ],
+  "types" : [ {
+    "type" : "object",
+    "object" : {
+      "typeName" : {
+        "name" : "Annotation",
+        "package" : "com.palantir.witchcraft.api.logging"
+      },
+      "fields" : [ {
+        "fieldName" : "timestamp",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "SAFELONG"
+        },
+        "docs" : "Time annotation was created (epoch microsecond value)\n"
+      }, {
+        "fieldName" : "value",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "Value encapsulated by this annotation\n"
+      }, {
+        "fieldName" : "endpoint",
+        "type" : {
+          "type" : "reference",
+          "reference" : {
+            "name" : "Endpoint",
+            "package" : "com.palantir.witchcraft.api.logging"
+          }
+        }
+      } ],
+      "docs" : "A Zipkin-compatible Annotation object."
+    }
+  }, {
+    "type" : "object",
+    "object" : {
+      "typeName" : {
+        "name" : "AuditLogV2",
+        "package" : "com.palantir.witchcraft.api.logging"
+      },
+      "fields" : [ {
+        "fieldName" : "type",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "\"audit.2\""
+      }, {
+        "fieldName" : "time",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "DATETIME"
+        }
+      }, {
+        "fieldName" : "uid",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "UserId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "User id (if available). This is the most downstream caller.\n"
+      }, {
+        "fieldName" : "sid",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "SessionId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "Session id (if available)\n"
+      }, {
+        "fieldName" : "tokenId",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "TokenId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "API token id (if available)\n"
+      }, {
+        "fieldName" : "orgId",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "OrganizationId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "Organization id (if available)"
+      }, {
+        "fieldName" : "traceId",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "TraceId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "Zipkin trace id (if available)\n"
+      }, {
+        "fieldName" : "otherUids",
+        "type" : {
+          "type" : "list",
+          "list" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "UserId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "All users upstream of the user currently taking an action. The first element in this list is the uid of the most upstream caller. This list does not include the `uid`.\n"
+      }, {
+        "fieldName" : "origin",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        },
+        "docs" : "Best-effort identifier of the originating machine, e.g. an IP address, a Kubernetes node identifier,\nor similar\n"
+      }, {
+        "fieldName" : "name",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "Name of the audit event, e.g. PUT_FILE\n"
+      }, {
+        "fieldName" : "result",
+        "type" : {
+          "type" : "reference",
+          "reference" : {
+            "name" : "AuditResult",
+            "package" : "com.palantir.witchcraft.api.logging"
+          }
+        },
+        "docs" : "Indicates whether the request was successful or the type of failure, e.g. ERROR or UNAUTHORIZED\n"
+      }, {
+        "fieldName" : "requestParams",
+        "type" : {
+          "type" : "map",
+          "map" : {
+            "keyType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            },
+            "valueType" : {
+              "type" : "primitive",
+              "primitive" : "ANY"
+            }
+          }
+        },
+        "docs" : "The parameters known at method invocation time.\n"
+      }, {
+        "fieldName" : "resultParams",
+        "type" : {
+          "type" : "map",
+          "map" : {
+            "keyType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            },
+            "valueType" : {
+              "type" : "primitive",
+              "primitive" : "ANY"
+            }
+          }
+        },
+        "docs" : "Information derived within a method, commonly parts of the return value.\n"
+      } ],
+      "docs" : "Definition of the audit.2 format.\n"
+    }
+  }, {
+    "type" : "object",
+    "object" : {
+      "typeName" : {
+        "name" : "AuditLogV3",
+        "package" : "com.palantir.witchcraft.api.logging"
+      },
+      "fields" : [ {
+        "fieldName" : "type",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "\"audit.3\""
+      }, {
+        "fieldName" : "deployment",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "The deployment that produced this log. Not exposed to downstream consumers."
+      }, {
+        "fieldName" : "host",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "The host of the service that produced this log."
+      }, {
+        "fieldName" : "product",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "The name of the product that produced this log."
+      }, {
+        "fieldName" : "productVersion",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "The version of the product that produced this log."
+      }, {
+        "fieldName" : "stack",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        },
+        "docs" : "The stack that this log was generated on."
+      }, {
+        "fieldName" : "service",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        },
+        "docs" : "The service name that produced this log."
+      }, {
+        "fieldName" : "environment",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        },
+        "docs" : "The environment that produced this log."
+      }, {
+        "fieldName" : "producerType",
+        "type" : {
+          "type" : "reference",
+          "reference" : {
+            "name" : "AuditProducer",
+            "package" : "com.palantir.witchcraft.api.logging"
+          }
+        },
+        "docs" : "How this audit log was produced, eg. from a backend Server, frontend Client etc."
+      }, {
+        "fieldName" : "organizations",
+        "type" : {
+          "type" : "list",
+          "list" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "Organization",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "A list of organizations that have been attributed to this log.\nAttribution is typically based on the user that originated this log, and the resources that\nthey targeted.\nNot exposed to downstream consumers.\n"
+      }, {
+        "fieldName" : "eventId",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "UUID"
+        },
+        "docs" : "Unique identifier for this audit log event. If there are multiple log entries associated with this\nparticular audit event, they will share the same eventId but will have different logEntryId and different\nsequenceId.\n"
+      }, {
+        "fieldName" : "logEntryId",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "UUID"
+            }
+          }
+        },
+        "docs" : "Unique identifier for this audit log."
+      }, {
+        "fieldName" : "sequenceId",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "INTEGER"
+            }
+          }
+        },
+        "docs" : "Orders the log entries when there are multiple entries for the same event."
+      }, {
+        "fieldName" : "userAgent",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        },
+        "docs" : "The user agent of the user that originated this log."
+      }, {
+        "fieldName" : "categories",
+        "type" : {
+          "type" : "list",
+          "list" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        },
+        "docs" : "All audit categories produced by this audit event.\nEach audit categories produces a set of keys that will be distributed between the request and\nresponse params.\n"
+      }, {
+        "fieldName" : "entities",
+        "type" : {
+          "type" : "list",
+          "list" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "ANY"
+            }
+          }
+        },
+        "docs" : "All contextualized entities present in the request and response params of this log.\nNote: Some resources cannot be contextualized, and will not be included in this list as a result.\n"
+      }, {
+        "fieldName" : "users",
+        "type" : {
+          "type" : "list",
+          "list" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "ContextualizedUser",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "All contextualized users present in the request and response params of this log, including the top level\nUUID of this log.\n"
+      }, {
+        "fieldName" : "origins",
+        "type" : {
+          "type" : "list",
+          "list" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        },
+        "docs" : "All addresses attached to the request. Contains information\nfrom unreliable sources such as the X-Forwarded-For header.\n\nThis value can be spoofed.\n"
+      }, {
+        "fieldName" : "sourceOrigin",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        },
+        "docs" : "Origin of the network request. If a request goes through a proxy,\nthis will contain the proxy''s address.\n\nThis value is verified through the TCP stack.\n"
+      }, {
+        "fieldName" : "requestParams",
+        "type" : {
+          "type" : "map",
+          "map" : {
+            "keyType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            },
+            "valueType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "SensitivityTaggedValue",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "The parameters known at method invocation time.\n\nNote that all keys must be known to the audit library. Typically, entries in the request and response\nparams will be dependent on the `categories` field defined above.\n",
+        "deprecated" : "Use requestFields instead.\n\nShould be translated to requestFields during emitting if requestFields is missing, by dropping the level\nfrom the SensitivityTaggedValue and directly using the payload as the value for the map.\n"
+      }, {
+        "fieldName" : "requestFields",
+        "type" : {
+          "type" : "map",
+          "map" : {
+            "keyType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            },
+            "valueType" : {
+              "type" : "primitive",
+              "primitive" : "ANY"
+            }
+          }
+        },
+        "docs" : "The fields known at method invocation time.\n\nNote that all keys must be known to the audit library. Typically, entries in the request and result\nfields will be dependent on the `categories` field defined above.\n\nThis replaces requestParams and will take priority if present.\n"
+      }, {
+        "fieldName" : "resultParams",
+        "type" : {
+          "type" : "map",
+          "map" : {
+            "keyType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            },
+            "valueType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "SensitivityTaggedValue",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "Information derived within a method, commonly parts of the return value.\n\nNote that all keys must be known to the audit library. Typically, entries in the request and response\nparams will be dependent on the `categories` field defined above.\n",
+        "deprecated" : "Use resultFields instead.\n\nShould be translated to resultFields during emitting if resultFields is missing, by dropping the level\nfrom the SensitivityTaggedValue and directly using the payload as the value for the map.\n"
+      }, {
+        "fieldName" : "resultFields",
+        "type" : {
+          "type" : "map",
+          "map" : {
+            "keyType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            },
+            "valueType" : {
+              "type" : "primitive",
+              "primitive" : "ANY"
+            }
+          }
+        },
+        "docs" : "Information derived within a method, commonly parts of the return value.\n\nNote that all keys must be known to the audit library. Typically, entries in the request and result\nfields will be dependent on the `categories` field defined above.\n\nThis replaces resultParams and will take priority if present.\n"
+      }, {
+        "fieldName" : "time",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "DATETIME"
+        }
+      }, {
+        "fieldName" : "uid",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "UserId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "User id (if available). This is the most downstream caller.\n"
+      }, {
+        "fieldName" : "sid",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "SessionId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "Session id (if available)\n"
+      }, {
+        "fieldName" : "tokenId",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "TokenId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "API token id (if available)\n"
+      }, {
+        "fieldName" : "orgId",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "OrganizationId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "Organization id (if available)"
+      }, {
+        "fieldName" : "traceId",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "TraceId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "Zipkin trace id (if available)\n"
+      }, {
+        "fieldName" : "origin",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        },
+        "docs" : "Best-effort identifier of the originating machine, e.g. an\nIP address, a Kubernetes node identifier, or similar.\n\nThis value can be spoofed.\n"
+      }, {
+        "fieldName" : "name",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "Name of the audit event, e.g. PUT_FILE\n"
+      }, {
+        "fieldName" : "result",
+        "type" : {
+          "type" : "reference",
+          "reference" : {
+            "name" : "AuditResult",
+            "package" : "com.palantir.witchcraft.api.logging"
+          }
+        },
+        "docs" : "Indicates whether the request was successful or the type of failure, e.g. ERROR or UNAUTHORIZED\n"
+      } ]
+    }
+  }, {
+    "type" : "enum",
+    "enum" : {
+      "typeName" : {
+        "name" : "AuditProducer",
+        "package" : "com.palantir.witchcraft.api.logging"
+      },
+      "values" : [ {
+        "value" : "SERVER"
+      }, {
+        "value" : "CLIENT"
+      } ]
+    }
+  }, {
+    "type" : "enum",
+    "enum" : {
+      "typeName" : {
+        "name" : "AuditResult",
+        "package" : "com.palantir.witchcraft.api.logging"
+      },
+      "values" : [ {
+        "value" : "SUCCESS"
+      }, {
+        "value" : "ERROR"
+      }, {
+        "value" : "UNAUTHORIZED"
+      }, {
+        "value" : "PARTIAL",
+        "docs" : "A result that has not yet been finalized. It may be missing fields from resultParams, and it is expected that a non-partial log should occur in the future with the same event ID.\n"
+      } ]
+    }
+  }, {
+    "type" : "object",
+    "object" : {
+      "typeName" : {
+        "name" : "ContextualizedUser",
+        "package" : "com.palantir.witchcraft.api.logging"
+      },
+      "fields" : [ {
+        "fieldName" : "uid",
+        "type" : {
+          "type" : "reference",
+          "reference" : {
+            "name" : "UserId",
+            "package" : "com.palantir.witchcraft.api.logging"
+          }
+        }
+      }, {
+        "fieldName" : "userName",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        }
+      }, {
+        "fieldName" : "firstName",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        }
+      }, {
+        "fieldName" : "lastName",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        }
+      }, {
+        "fieldName" : "groups",
+        "type" : {
+          "type" : "list",
+          "list" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        }
+      }, {
+        "fieldName" : "realm",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        }
+      } ]
+    }
+  }, {
+    "type" : "union",
+    "union" : {
+      "typeName" : {
+        "name" : "Diagnostic",
+        "package" : "com.palantir.witchcraft.api.logging"
+      },
+      "union" : [ {
+        "fieldName" : "generic",
+        "type" : {
+          "type" : "reference",
+          "reference" : {
+            "name" : "GenericDiagnostic",
+            "package" : "com.palantir.witchcraft.api.logging"
+          }
+        }
+      }, {
+        "fieldName" : "threadDump",
+        "type" : {
+          "type" : "reference",
+          "reference" : {
+            "name" : "ThreadDumpV1",
+            "package" : "com.palantir.witchcraft.api.logging"
+          }
+        }
+      } ]
+    }
+  }, {
+    "type" : "object",
+    "object" : {
+      "typeName" : {
+        "name" : "DiagnosticLogV1",
+        "package" : "com.palantir.witchcraft.api.logging"
+      },
+      "fields" : [ {
+        "fieldName" : "type",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "\"diagnostic.1\""
+      }, {
+        "fieldName" : "time",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "DATETIME"
+        }
+      }, {
+        "fieldName" : "diagnostic",
+        "type" : {
+          "type" : "reference",
+          "reference" : {
+            "name" : "Diagnostic",
+            "package" : "com.palantir.witchcraft.api.logging"
+          }
+        },
+        "docs" : "The diagnostic being logged."
+      }, {
+        "fieldName" : "unsafeParams",
+        "type" : {
+          "type" : "map",
+          "map" : {
+            "keyType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            },
+            "valueType" : {
+              "type" : "primitive",
+              "primitive" : "ANY"
+            }
+          }
+        },
+        "docs" : "Unredacted parameters\n"
+      } ],
+      "docs" : "Definition of the diagnostic.1 format.\n"
+    }
+  }, {
+    "type" : "object",
+    "object" : {
+      "typeName" : {
+        "name" : "Endpoint",
+        "package" : "com.palantir.witchcraft.api.logging"
+      },
+      "fields" : [ {
+        "fieldName" : "serviceName",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "Name of the service that generated the annotation\n"
+      }, {
+        "fieldName" : "ipv4",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        },
+        "docs" : "IPv4 address of the machine that generated this annotation (`xxx.xxx.xxx.xxx`)\n"
+      }, {
+        "fieldName" : "ipv6",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        },
+        "docs" : "IPv6 address of the machine that generated this annotation (standard hextet form)\n"
+      } ]
+    }
+  }, {
+    "type" : "object",
+    "object" : {
+      "typeName" : {
+        "name" : "EventLogV1",
+        "package" : "com.palantir.witchcraft.api.logging"
+      },
+      "fields" : [ {
+        "fieldName" : "type",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        }
+      }, {
+        "fieldName" : "time",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "DATETIME"
+        }
+      }, {
+        "fieldName" : "eventName",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "Dot-delimited name of event, e.g. `com.foundry.compass.api.Compass.http.ping.failures`\n"
+      }, {
+        "fieldName" : "eventType",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "Type of event being represented, e.g. `gauge`, `histogram`, `counter`\n"
+      }, {
+        "fieldName" : "values",
+        "type" : {
+          "type" : "map",
+          "map" : {
+            "keyType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            },
+            "valueType" : {
+              "type" : "primitive",
+              "primitive" : "ANY"
+            }
+          }
+        },
+        "docs" : "Observations, measurements and context associated with the event\n"
+      }, {
+        "fieldName" : "uid",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "UserId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "User id (if available)\n"
+      }, {
+        "fieldName" : "sid",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "SessionId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "Session id (if available)\n"
+      }, {
+        "fieldName" : "tokenId",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "TokenId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "API token id (if available)\n"
+      }, {
+        "fieldName" : "orgId",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "OrganizationId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "Organization id (if available)"
+      }, {
+        "fieldName" : "unsafeParams",
+        "type" : {
+          "type" : "map",
+          "map" : {
+            "keyType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            },
+            "valueType" : {
+              "type" : "primitive",
+              "primitive" : "ANY"
+            }
+          }
+        },
+        "docs" : "Unsafe metadata describing the event\n"
+      } ],
+      "docs" : "Definition of the event.1 format."
+    }
+  }, {
+    "type" : "object",
+    "object" : {
+      "typeName" : {
+        "name" : "EventLogV2",
+        "package" : "com.palantir.witchcraft.api.logging"
+      },
+      "fields" : [ {
+        "fieldName" : "type",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        }
+      }, {
+        "fieldName" : "time",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "DATETIME"
+        }
+      }, {
+        "fieldName" : "eventName",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "Dot-delimited name of event, e.g. `com.foundry.compass.api.Compass.http.ping.failures`\n"
+      }, {
+        "fieldName" : "values",
+        "type" : {
+          "type" : "map",
+          "map" : {
+            "keyType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            },
+            "valueType" : {
+              "type" : "primitive",
+              "primitive" : "ANY"
+            }
+          }
+        },
+        "docs" : "Observations, measurements and context associated with the event\n"
+      }, {
+        "fieldName" : "uid",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "UserId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "User id (if available)\n"
+      }, {
+        "fieldName" : "sid",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "SessionId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "Session id (if available)\n"
+      }, {
+        "fieldName" : "tokenId",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "TokenId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "API token id (if available)\n"
+      }, {
+        "fieldName" : "orgId",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "OrganizationId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "Organization id (if available)"
+      }, {
+        "fieldName" : "traceId",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "TraceId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "Zipkin trace id (if available)\n"
+      }, {
+        "fieldName" : "unsafeParams",
+        "type" : {
+          "type" : "map",
+          "map" : {
+            "keyType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            },
+            "valueType" : {
+              "type" : "primitive",
+              "primitive" : "ANY"
+            }
+          }
+        },
+        "docs" : "Unsafe metadata describing the event\n"
+      }, {
+        "fieldName" : "tags",
+        "type" : {
+          "type" : "map",
+          "map" : {
+            "keyType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            },
+            "valueType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        },
+        "docs" : "Additional dimensions that describe the instance of the log event"
+      } ],
+      "docs" : "Definition of the event.2 format."
+    }
+  }, {
+    "type" : "object",
+    "object" : {
+      "typeName" : {
+        "name" : "GenericDiagnostic",
+        "package" : "com.palantir.witchcraft.api.logging"
+      },
+      "fields" : [ {
+        "fieldName" : "diagnosticType",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "An identifier for the type of diagnostic represented."
+      }, {
+        "fieldName" : "value",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "ANY"
+        },
+        "docs" : "Observations, measurements and context associated with the diagnostic."
+      } ]
+    }
+  }, {
+    "type" : "enum",
+    "enum" : {
+      "typeName" : {
+        "name" : "LogLevel",
+        "package" : "com.palantir.witchcraft.api.logging"
+      },
+      "values" : [ {
+        "value" : "FATAL"
+      }, {
+        "value" : "ERROR"
+      }, {
+        "value" : "WARN"
+      }, {
+        "value" : "INFO"
+      }, {
+        "value" : "DEBUG"
+      }, {
+        "value" : "TRACE"
+      } ]
+    }
+  }, {
+    "type" : "object",
+    "object" : {
+      "typeName" : {
+        "name" : "MetricLogV1",
+        "package" : "com.palantir.witchcraft.api.logging"
+      },
+      "fields" : [ {
+        "fieldName" : "type",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        }
+      }, {
+        "fieldName" : "time",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "DATETIME"
+        }
+      }, {
+        "fieldName" : "metricName",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "Dot-delimited name of metric, e.g. `com.foundry.compass.api.Compass.http.ping.failures`\n"
+      }, {
+        "fieldName" : "metricType",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "Type of metric being represented, e.g. `gauge`, `histogram`, `counter`\n"
+      }, {
+        "fieldName" : "values",
+        "type" : {
+          "type" : "map",
+          "map" : {
+            "keyType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            },
+            "valueType" : {
+              "type" : "primitive",
+              "primitive" : "ANY"
+            }
+          }
+        },
+        "docs" : "Observations, measurements and context associated with the metric\n"
+      }, {
+        "fieldName" : "samples",
+        "type" : {
+          "type" : "list",
+          "list" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "Sample",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "List of samples (if any) associated with the metric\n"
+      }, {
+        "fieldName" : "tags",
+        "type" : {
+          "type" : "map",
+          "map" : {
+            "keyType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            },
+            "valueType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        },
+        "docs" : "Additional dimensions that describe the instance of the metric\n"
+      }, {
+        "fieldName" : "uid",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "UserId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "User id (if available)\n"
+      }, {
+        "fieldName" : "sid",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "SessionId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "Session id (if available)\n"
+      }, {
+        "fieldName" : "tokenId",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "TokenId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "API token id (if available)\n"
+      }, {
+        "fieldName" : "orgId",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "OrganizationId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "Organization id (if available)"
+      }, {
+        "fieldName" : "unsafeParams",
+        "type" : {
+          "type" : "map",
+          "map" : {
+            "keyType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            },
+            "valueType" : {
+              "type" : "primitive",
+              "primitive" : "ANY"
+            }
+          }
+        },
+        "docs" : "Unsafe metadata describing the event\n"
+      } ],
+      "docs" : "Definition of the metric.1 format."
+    }
+  }, {
+    "type" : "object",
+    "object" : {
+      "typeName" : {
+        "name" : "Organization",
+        "package" : "com.palantir.witchcraft.api.logging"
+      },
+      "fields" : [ {
+        "fieldName" : "id",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "Organization RID. Not exposed to downstream consumers."
+      }, {
+        "fieldName" : "reason",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "Explanation of why this organization was attributed to this log."
+      } ]
+    }
+  }, {
+    "type" : "alias",
+    "alias" : {
+      "typeName" : {
+        "name" : "OrganizationId",
+        "package" : "com.palantir.witchcraft.api.logging"
+      },
+      "alias" : {
+        "type" : "primitive",
+        "primitive" : "STRING"
+      }
+    }
+  }, {
+    "type" : "union",
+    "union" : {
+      "typeName" : {
+        "name" : "RequestLog",
+        "package" : "com.palantir.witchcraft.api.logging"
+      },
+      "union" : [ {
+        "fieldName" : "v1",
+        "type" : {
+          "type" : "reference",
+          "reference" : {
+            "name" : "RequestLogV1",
+            "package" : "com.palantir.witchcraft.api.logging"
+          }
+        }
+      }, {
+        "fieldName" : "v2",
+        "type" : {
+          "type" : "reference",
+          "reference" : {
+            "name" : "RequestLogV2",
+            "package" : "com.palantir.witchcraft.api.logging"
+          }
+        }
+      } ]
+    }
+  }, {
+    "type" : "object",
+    "object" : {
+      "typeName" : {
+        "name" : "RequestLogV1",
+        "package" : "com.palantir.witchcraft.api.logging"
+      },
+      "fields" : [ {
+        "fieldName" : "type",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        }
+      }, {
+        "fieldName" : "time",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "DATETIME"
+        }
+      }, {
+        "fieldName" : "method",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        },
+        "docs" : "HTTP method of request\n"
+      }, {
+        "fieldName" : "protocol",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "Protocol, e.g. `HTTP/1.1`, `HTTP/2`\n"
+      }, {
+        "fieldName" : "path",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "Path of request. If templated, the unrendered path, e.g.: `/catalog/dataset/{datasetId}`, `/{rid}/paths/contents/{path:.*}`.\n"
+      }, {
+        "fieldName" : "pathParams",
+        "type" : {
+          "type" : "map",
+          "map" : {
+            "keyType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            },
+            "valueType" : {
+              "type" : "primitive",
+              "primitive" : "ANY"
+            }
+          }
+        },
+        "docs" : "Known-safe path parameters\n"
+      }, {
+        "fieldName" : "queryParams",
+        "type" : {
+          "type" : "map",
+          "map" : {
+            "keyType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            },
+            "valueType" : {
+              "type" : "primitive",
+              "primitive" : "ANY"
+            }
+          }
+        },
+        "docs" : "Known-safe query parameters\n"
+      }, {
+        "fieldName" : "headerParams",
+        "type" : {
+          "type" : "map",
+          "map" : {
+            "keyType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            },
+            "valueType" : {
+              "type" : "primitive",
+              "primitive" : "ANY"
+            }
+          }
+        },
+        "docs" : "Known-safe header parameters\n"
+      }, {
+        "fieldName" : "bodyParams",
+        "type" : {
+          "type" : "map",
+          "map" : {
+            "keyType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            },
+            "valueType" : {
+              "type" : "primitive",
+              "primitive" : "ANY"
+            }
+          }
+        },
+        "docs" : "Known-safe body parameters\n"
+      }, {
+        "fieldName" : "status",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "INTEGER"
+        },
+        "docs" : "HTTP status code of response\n"
+      }, {
+        "fieldName" : "requestSize",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "Size of request (bytes). string to allow large numbers.\n"
+      }, {
+        "fieldName" : "responseSize",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "Size of response (bytes). string to allow large numbers.\n"
+      }, {
+        "fieldName" : "duration",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "INTEGER"
+        },
+        "docs" : "Amount of time spent handling request (microseconds)\n"
+      }, {
+        "fieldName" : "uid",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "UserId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "User id (if available)\n"
+      }, {
+        "fieldName" : "sid",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "SessionId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "Session id (if available)\n"
+      }, {
+        "fieldName" : "tokenId",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "TokenId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "API token id (if available)\n"
+      }, {
+        "fieldName" : "orgId",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "OrganizationId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "Organization id (if available)"
+      }, {
+        "fieldName" : "traceId",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "TraceId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "Zipkin trace id (if available)\n"
+      }, {
+        "fieldName" : "unsafeParams",
+        "type" : {
+          "type" : "map",
+          "map" : {
+            "keyType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            },
+            "valueType" : {
+              "type" : "primitive",
+              "primitive" : "ANY"
+            }
+          }
+        },
+        "docs" : "Unredacted parameters such as path, query and header parameters\n"
+      } ],
+      "docs" : "Definition of the request.1 format.\n"
+    }
+  }, {
+    "type" : "object",
+    "object" : {
+      "typeName" : {
+        "name" : "RequestLogV2",
+        "package" : "com.palantir.witchcraft.api.logging"
+      },
+      "fields" : [ {
+        "fieldName" : "type",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        }
+      }, {
+        "fieldName" : "time",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "DATETIME"
+        }
+      }, {
+        "fieldName" : "method",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        },
+        "docs" : "HTTP method of request\n"
+      }, {
+        "fieldName" : "protocol",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "Protocol, e.g. `HTTP/1.1`, `HTTP/2`\n"
+      }, {
+        "fieldName" : "path",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "Path of request. If templated, the unrendered path, e.g.: `/catalog/dataset/{datasetId}`, `/{rid}/paths/contents/{path:.*}`.\n"
+      }, {
+        "fieldName" : "params",
+        "type" : {
+          "type" : "map",
+          "map" : {
+            "keyType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            },
+            "valueType" : {
+              "type" : "primitive",
+              "primitive" : "ANY"
+            }
+          }
+        },
+        "docs" : "Known-safe parameters\n"
+      }, {
+        "fieldName" : "status",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "INTEGER"
+        },
+        "docs" : "HTTP status code of response\n"
+      }, {
+        "fieldName" : "requestSize",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "SAFELONG"
+        },
+        "docs" : "Size of request (bytes)\n"
+      }, {
+        "fieldName" : "responseSize",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "SAFELONG"
+        },
+        "docs" : "Size of response (bytes)\n"
+      }, {
+        "fieldName" : "duration",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "SAFELONG"
+        },
+        "docs" : "Amount of time spent handling request (microseconds)\n"
+      }, {
+        "fieldName" : "uid",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "UserId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "User id (if available)\n"
+      }, {
+        "fieldName" : "sid",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "SessionId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "Session id (if available)\n"
+      }, {
+        "fieldName" : "tokenId",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "TokenId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "API token id (if available)\n"
+      }, {
+        "fieldName" : "orgId",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "OrganizationId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "Organization id (if available)"
+      }, {
+        "fieldName" : "traceId",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "TraceId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "Zipkin trace id (if available)\n"
+      }, {
+        "fieldName" : "unsafeParams",
+        "type" : {
+          "type" : "map",
+          "map" : {
+            "keyType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            },
+            "valueType" : {
+              "type" : "primitive",
+              "primitive" : "ANY"
+            }
+          }
+        },
+        "docs" : "Unredacted parameters such as path, query and header parameters\n"
+      } ],
+      "docs" : "Definition of the request.2 format.\n"
+    }
+  }, {
+    "type" : "object",
+    "object" : {
+      "typeName" : {
+        "name" : "Sample",
+        "package" : "com.palantir.witchcraft.api.logging"
+      },
+      "fields" : [ {
+        "fieldName" : "value",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "ANY"
+        },
+        "docs" : "Exact value of this metric sample"
+      }, {
+        "fieldName" : "time",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "DATETIME"
+        },
+        "docs" : "RFC3339Nano UTC datetime string of when the sample was taken"
+      }, {
+        "fieldName" : "traceId",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "TraceId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "Zipkin trace id associated with this sample, if available"
+      } ]
+    }
+  }, {
+    "type" : "object",
+    "object" : {
+      "typeName" : {
+        "name" : "SensitivityTaggedValue",
+        "package" : "com.palantir.witchcraft.api.logging"
+      },
+      "fields" : [ {
+        "fieldName" : "level",
+        "type" : {
+          "type" : "list",
+          "list" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        },
+        "docs" : "Sensitivity level of this value; must be a known level in sls-spec.\n"
+      }, {
+        "fieldName" : "payload",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "ANY"
+        }
+      } ]
+    }
+  }, {
+    "type" : "object",
+    "object" : {
+      "typeName" : {
+        "name" : "ServiceLogV1",
+        "package" : "com.palantir.witchcraft.api.logging"
+      },
+      "fields" : [ {
+        "fieldName" : "type",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "\"service.1\""
+      }, {
+        "fieldName" : "level",
+        "type" : {
+          "type" : "reference",
+          "reference" : {
+            "name" : "LogLevel",
+            "package" : "com.palantir.witchcraft.api.logging"
+          }
+        },
+        "docs" : "The logger output level. One of {FATAL,ERROR,WARN,INFO,DEBUG,TRACE} based on [log level coding guidelines](https://github.com/palantir/gradle-baseline/blob/develop/docs/best-practices/java-coding-guidelines/readme.md#log-levels)\n"
+      }, {
+        "fieldName" : "time",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "DATETIME"
+        },
+        "docs" : "RFC3339Nano UTC datetime string when the log event was emitted"
+      }, {
+        "fieldName" : "origin",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        },
+        "docs" : "Class or file name. May include line number."
+      }, {
+        "fieldName" : "thread",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        },
+        "docs" : "Thread name"
+      }, {
+        "fieldName" : "message",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "Log message. Palantir Java services using slf4j should not use slf4j placeholders ({}). Logs obtained from 3rd party libraries or services that use slf4j and contain slf4j placeholders will always produce `unsafeParams` with numeric indexes corresponding to the zero-indexed order of placeholders. Renderers should substitute numeric parameters from `unsafeParams` and may leave placeholders that do not match indexes as the original placeholder text.\n"
+      }, {
+        "fieldName" : "safe",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "BOOLEAN"
+            }
+          }
+        },
+        "docs" : "Describes the safety of this log event based on prior knowledge within the application which produced the message. This field should not be set to `true` without _total_ confidence that it is correct. * _empty_:  Considered unsafe unless the logging pipeline has special configuration for this `origin`. Eventually these will all be equivalent to `false`. * `true`: All safe components can be trusted. * `false`: Event is _unsafe_ and cannot be exported.\n"
+      }, {
+        "fieldName" : "params",
+        "type" : {
+          "type" : "map",
+          "map" : {
+            "keyType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            },
+            "valueType" : {
+              "type" : "primitive",
+              "primitive" : "ANY"
+            }
+          }
+        },
+        "docs" : "Known-safe parameters (redaction may be used to make params knowably safe, but is not required)."
+      }, {
+        "fieldName" : "uid",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "UserId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "User id (if available).\n"
+      }, {
+        "fieldName" : "sid",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "SessionId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "Session id (if available)"
+      }, {
+        "fieldName" : "tokenId",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "TokenId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "API token id (if available)"
+      }, {
+        "fieldName" : "orgId",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "OrganizationId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "Organization id (if available)"
+      }, {
+        "fieldName" : "traceId",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "TraceId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "Zipkin trace id (if available)"
+      }, {
+        "fieldName" : "stacktrace",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        },
+        "docs" : "Language-specific stack trace. Content is knowably safe. Renderers should substitute named placeholders ({name}, for name as a key) with keyed value from unsafeParams and leave non-matching keys as the original placeholder text.\n"
+      }, {
+        "fieldName" : "unsafeParams",
+        "type" : {
+          "type" : "map",
+          "map" : {
+            "keyType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            },
+            "valueType" : {
+              "type" : "primitive",
+              "primitive" : "ANY"
+            }
+          }
+        },
+        "docs" : "Unredacted parameters"
+      }, {
+        "fieldName" : "tags",
+        "type" : {
+          "type" : "map",
+          "map" : {
+            "keyType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            },
+            "valueType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        },
+        "docs" : "Additional dimensions that describe the instance of the log event"
+      } ],
+      "docs" : "Definition of the service.1 format.\n"
+    }
+  }, {
+    "type" : "alias",
+    "alias" : {
+      "typeName" : {
+        "name" : "SessionId",
+        "package" : "com.palantir.witchcraft.api.logging"
+      },
+      "alias" : {
+        "type" : "primitive",
+        "primitive" : "STRING"
+      }
+    }
+  }, {
+    "type" : "object",
+    "object" : {
+      "typeName" : {
+        "name" : "Span",
+        "package" : "com.palantir.witchcraft.api.logging"
+      },
+      "fields" : [ {
+        "fieldName" : "traceId",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "16-digit hex trace identifier\n"
+      }, {
+        "fieldName" : "id",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "16-digit hex span identifier\n"
+      }, {
+        "fieldName" : "name",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "Name of the span (typically the operation/RPC/method name for corresponding to this span)\n"
+      }, {
+        "fieldName" : "parentId",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        },
+        "docs" : "16-digit hex identifer of the parent span\n"
+      }, {
+        "fieldName" : "timestamp",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "SAFELONG"
+        },
+        "docs" : "Timestamp of the start of this span (epoch microsecond value)\n"
+      }, {
+        "fieldName" : "duration",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "SAFELONG"
+        },
+        "docs" : "Duration of this span (microseconds)\n"
+      }, {
+        "fieldName" : "annotations",
+        "type" : {
+          "type" : "list",
+          "list" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "Annotation",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        }
+      }, {
+        "fieldName" : "tags",
+        "type" : {
+          "type" : "map",
+          "map" : {
+            "keyType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            },
+            "valueType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        },
+        "docs" : "Additional dimensions that describe the instance of the trace span\n"
+      } ],
+      "docs" : "A Zipkin-compatible Span object."
+    }
+  }, {
+    "type" : "object",
+    "object" : {
+      "typeName" : {
+        "name" : "StackFrameV1",
+        "package" : "com.palantir.witchcraft.api.logging"
+      },
+      "fields" : [ {
+        "fieldName" : "address",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        },
+        "docs" : "The address of the execution point of this stack frame. This is a string because a safelong can't represent the full 64 bit address space.\n"
+      }, {
+        "fieldName" : "procedure",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        },
+        "docs" : "The identifier of the procedure containing the execution point of this stack frame. This is a fully qualified method name in Java and a demangled symbol name in native code, for example. Note that procedure names may include unsafe information if a service is, for exmaple, running user-defined code. It must be safely redacted.\n"
+      }, {
+        "fieldName" : "file",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        },
+        "docs" : "The name of the file containing the source location of the execution point of this stack frame. Note that file names may include unsafe information if a service is, for example, running user-defined code. It must be safely redacted.\n"
+      }, {
+        "fieldName" : "line",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "INTEGER"
+            }
+          }
+        },
+        "docs" : "The line number of the source location of the execution point of this stack frame.\n"
+      }, {
+        "fieldName" : "params",
+        "type" : {
+          "type" : "map",
+          "map" : {
+            "keyType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            },
+            "valueType" : {
+              "type" : "primitive",
+              "primitive" : "ANY"
+            }
+          }
+        },
+        "docs" : "Other frame-level information."
+      } ]
+    }
+  }, {
+    "type" : "object",
+    "object" : {
+      "typeName" : {
+        "name" : "ThreadDumpV1",
+        "package" : "com.palantir.witchcraft.api.logging"
+      },
+      "fields" : [ {
+        "fieldName" : "threads",
+        "type" : {
+          "type" : "list",
+          "list" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "ThreadInfoV1",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "Information about each of the threads in the thread dump. \"Thread\" may refer to a userland thread such as a goroutine, or an OS-level thread.\n"
+      } ]
+    }
+  }, {
+    "type" : "object",
+    "object" : {
+      "typeName" : {
+        "name" : "ThreadInfoV1",
+        "package" : "com.palantir.witchcraft.api.logging"
+      },
+      "fields" : [ {
+        "fieldName" : "id",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "SAFELONG"
+            }
+          }
+        },
+        "docs" : "The ID of the thread."
+      }, {
+        "fieldName" : "name",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        },
+        "docs" : "The name of the thread. Note that thread names may include unsafe information such as the path of the HTTP request being processed. It must be safely redacted.\n"
+      }, {
+        "fieldName" : "stackTrace",
+        "type" : {
+          "type" : "list",
+          "list" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "StackFrameV1",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        },
+        "docs" : "A list of stack frames for the thread, ordered with the current frame first.\n"
+      }, {
+        "fieldName" : "params",
+        "type" : {
+          "type" : "map",
+          "map" : {
+            "keyType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            },
+            "valueType" : {
+              "type" : "primitive",
+              "primitive" : "ANY"
+            }
+          }
+        },
+        "docs" : "Other thread-level information."
+      } ]
+    }
+  }, {
+    "type" : "alias",
+    "alias" : {
+      "typeName" : {
+        "name" : "TokenId",
+        "package" : "com.palantir.witchcraft.api.logging"
+      },
+      "alias" : {
+        "type" : "primitive",
+        "primitive" : "STRING"
+      }
+    }
+  }, {
+    "type" : "alias",
+    "alias" : {
+      "typeName" : {
+        "name" : "TraceId",
+        "package" : "com.palantir.witchcraft.api.logging"
+      },
+      "alias" : {
+        "type" : "primitive",
+        "primitive" : "STRING"
+      }
+    }
+  }, {
+    "type" : "object",
+    "object" : {
+      "typeName" : {
+        "name" : "TraceLogV1",
+        "package" : "com.palantir.witchcraft.api.logging"
+      },
+      "fields" : [ {
+        "fieldName" : "type",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        }
+      }, {
+        "fieldName" : "time",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "DATETIME"
+        }
+      }, {
+        "fieldName" : "uid",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "UserId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        }
+      }, {
+        "fieldName" : "sid",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "SessionId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        }
+      }, {
+        "fieldName" : "tokenId",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "TokenId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        }
+      }, {
+        "fieldName" : "orgId",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "reference",
+              "reference" : {
+                "name" : "OrganizationId",
+                "package" : "com.palantir.witchcraft.api.logging"
+              }
+            }
+          }
+        }
+      }, {
+        "fieldName" : "unsafeParams",
+        "type" : {
+          "type" : "map",
+          "map" : {
+            "keyType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            },
+            "valueType" : {
+              "type" : "primitive",
+              "primitive" : "ANY"
+            }
+          }
+        }
+      }, {
+        "fieldName" : "span",
+        "type" : {
+          "type" : "reference",
+          "reference" : {
+            "name" : "Span",
+            "package" : "com.palantir.witchcraft.api.logging"
+          }
+        }
+      } ],
+      "docs" : "Definition of the trace.1 format.\n"
+    }
+  }, {
+    "type" : "union",
+    "union" : {
+      "typeName" : {
+        "name" : "UnionEventLog",
+        "package" : "com.palantir.witchcraft.api.logging"
+      },
+      "union" : [ {
+        "fieldName" : "eventLog",
+        "type" : {
+          "type" : "reference",
+          "reference" : {
+            "name" : "EventLogV1",
+            "package" : "com.palantir.witchcraft.api.logging"
+          }
+        }
+      }, {
+        "fieldName" : "eventLogV2",
+        "type" : {
+          "type" : "reference",
+          "reference" : {
+            "name" : "EventLogV2",
+            "package" : "com.palantir.witchcraft.api.logging"
+          }
+        }
+      } ],
+      "docs" : "Union type containing log types that are logged to event.log."
+    }
+  }, {
+    "type" : "alias",
+    "alias" : {
+      "typeName" : {
+        "name" : "UserId",
+        "package" : "com.palantir.witchcraft.api.logging"
+      },
+      "alias" : {
+        "type" : "primitive",
+        "primitive" : "STRING"
+      }
+    }
+  }, {
+    "type" : "object",
+    "object" : {
+      "typeName" : {
+        "name" : "WitchcraftEnvelopeV1",
+        "package" : "com.palantir.witchcraft.api.logging"
+      },
+      "fields" : [ {
+        "fieldName" : "type",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "\"envelope.1\""
+      }, {
+        "fieldName" : "deployment",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "Color or other codename for the customer infra"
+      }, {
+        "fieldName" : "environment",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "prod/staging/integration etc."
+      }, {
+        "fieldName" : "environmentId",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "Skylab environment ID"
+      }, {
+        "fieldName" : "host",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "Hostname where the log message originated"
+      }, {
+        "fieldName" : "nodeId",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "Skylab node ID"
+      }, {
+        "fieldName" : "service",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "Skylab service name"
+      }, {
+        "fieldName" : "serviceId",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "Skylab service ID"
+      }, {
+        "fieldName" : "stack",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "Skylab stack name"
+      }, {
+        "fieldName" : "stackId",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "Skylab stack ID"
+      }, {
+        "fieldName" : "product",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "Artifact part of product's maven coordinate"
+      }, {
+        "fieldName" : "productVersion",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "Artifact semantic version"
+      }, {
+        "fieldName" : "payload",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "ANY"
+        },
+        "docs" : "One of the Witchcraft log types; see [witchcraft-api](https://github.com/palantir/witchcraft-api) for details."
+      }, {
+        "fieldName" : "apolloEntityId",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "Apollo entity id"
+      }, {
+        "fieldName" : "apolloEnvironmentId",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "Apollo environment id"
+      } ],
+      "docs" : "Wraps a log entry with metadata on where it is coming from and the source service that generated it.\n"
+    }
+  }, {
+    "type" : "object",
+    "object" : {
+      "typeName" : {
+        "name" : "WrappedLogV1",
+        "package" : "com.palantir.witchcraft.api.logging"
+      },
+      "fields" : [ {
+        "fieldName" : "type",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "\"wrapped.1\""
+      }, {
+        "fieldName" : "payload",
+        "type" : {
+          "type" : "reference",
+          "reference" : {
+            "name" : "WrappedLogV1Payload",
+            "package" : "com.palantir.witchcraft.api.logging"
+          }
+        }
+      }, {
+        "fieldName" : "entityName",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : "Artifact part of entity's maven coordinate"
+      }, {
+        "fieldName" : "entityVersion",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        }
+      }, {
+        "fieldName" : "service",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        },
+        "docs" : "Defaults to the wrapped log producer's Skylab service name."
+      }, {
+        "fieldName" : "serviceId",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        },
+        "docs" : "Defaults to the wrapped log producer's Skylab service ID."
+      }, {
+        "fieldName" : "stack",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        },
+        "docs" : "Defaults to the wrapped log producer's Skylab stack name."
+      }, {
+        "fieldName" : "stackId",
+        "type" : {
+          "type" : "optional",
+          "optional" : {
+            "itemType" : {
+              "type" : "primitive",
+              "primitive" : "STRING"
+            }
+          }
+        },
+        "docs" : "Defaults to the wrapped log producer's Skylab stack ID."
+      } ],
+      "docs" : "Wraps a log entry with entity information.\n"
+    }
+  }, {
+    "type" : "union",
+    "union" : {
+      "typeName" : {
+        "name" : "WrappedLogV1Payload",
+        "package" : "com.palantir.witchcraft.api.logging"
+      },
+      "union" : [ {
+        "fieldName" : "serviceLogV1",
+        "type" : {
+          "type" : "reference",
+          "reference" : {
+            "name" : "ServiceLogV1",
+            "package" : "com.palantir.witchcraft.api.logging"
+          }
+        }
+      }, {
+        "fieldName" : "requestLogV2",
+        "type" : {
+          "type" : "reference",
+          "reference" : {
+            "name" : "RequestLogV2",
+            "package" : "com.palantir.witchcraft.api.logging"
+          }
+        }
+      }, {
+        "fieldName" : "traceLogV1",
+        "type" : {
+          "type" : "reference",
+          "reference" : {
+            "name" : "TraceLogV1",
+            "package" : "com.palantir.witchcraft.api.logging"
+          }
+        }
+      }, {
+        "fieldName" : "eventLogV2",
+        "type" : {
+          "type" : "reference",
+          "reference" : {
+            "name" : "EventLogV2",
+            "package" : "com.palantir.witchcraft.api.logging"
+          }
+        }
+      }, {
+        "fieldName" : "metricLogV1",
+        "type" : {
+          "type" : "reference",
+          "reference" : {
+            "name" : "MetricLogV1",
+            "package" : "com.palantir.witchcraft.api.logging"
+          }
+        }
+      }, {
+        "fieldName" : "auditLogV2",
+        "type" : {
+          "type" : "reference",
+          "reference" : {
+            "name" : "AuditLogV2",
+            "package" : "com.palantir.witchcraft.api.logging"
+          }
+        }
+      }, {
+        "fieldName" : "auditLogV3",
+        "type" : {
+          "type" : "reference",
+          "reference" : {
+            "name" : "AuditLogV3",
+            "package" : "com.palantir.witchcraft.api.logging"
+          }
+        }
+      }, {
+        "fieldName" : "diagnosticLogV1",
+        "type" : {
+          "type" : "reference",
+          "reference" : {
+            "name" : "DiagnosticLogV1",
+            "package" : "com.palantir.witchcraft.api.logging"
+          }
+        }
+      } ]
+    }
+  } ],
+  "services" : [ ],
+  "extensions" : {
+    "recommended-product-dependencies" : [ ]
+  }
+}

--- a/witchcraft-metrics/src/clock.rs
+++ b/witchcraft-metrics/src/clock.rs
@@ -34,7 +34,7 @@ impl Clock for SystemClock {
 }
 
 #[cfg(test)]
-pub mod test {
+pub(crate) mod test {
     use super::*;
     use parking_lot::Mutex;
     use std::time::Duration;

--- a/witchcraft-metrics/src/metric_id.rs
+++ b/witchcraft-metrics/src/metric_id.rs
@@ -118,7 +118,7 @@ impl<'a> Iterator for TagsIter<'a> {
     }
 }
 
-impl<'a> ExactSizeIterator for TagsIter<'a> {}
+impl ExactSizeIterator for TagsIter<'_> {}
 
 #[cfg(test)]
 mod test {

--- a/witchcraft-metrics/src/registry.rs
+++ b/witchcraft-metrics/src/registry.rs
@@ -331,7 +331,7 @@ impl<'a> Iterator for MetricsIter<'a> {
     }
 }
 
-impl<'a> ExactSizeIterator for MetricsIter<'a> {}
+impl ExactSizeIterator for MetricsIter<'_> {}
 
 #[cfg(test)]
 mod test {


### PR DESCRIPTION
Previously, the only standard logger compatible with `witchcraft-log` was the one embedded in `witchcraft-server`, which isn't usable in things like CLIs or unit tests.

This adds a Witchcraft equivalent to the [env_logger](https://docs.rs/env_logger) crate, which contains a simple `Log` implementation that writes `service.1` formatted JSON to standard error, with level filtering via an environment variable. The current API exposure is very minimal, but we can expand that over time as needed.

Along with the core `witchcraft-env-logger` crate, this PR defines `witchcraft-logging-api`, which just holds the Conjure logging API definitions, and the `witchcraft-log-util` crate, which holds some functionality that's shared between `witchcraft-env-logger` and `witchcraft-server`.