### PR TITLE
Export the full codegen module hierarchy

### DIFF
--- a/witchcraft-log-util/src/service.rs
+++ b/witchcraft-log-util/src/service.rs
@@ -18,7 +18,7 @@ use std::{error, thread};
 use conjure_error::ErrorKind;
 use conjure_object::Utc;
 use witchcraft_log::{Level, Record, mdc};
-use witchcraft_logging_api::{
+use witchcraft_logging_api::objects::{
     LogLevel, OrganizationId, ServiceLogV1, SessionId, TokenId, TraceId, UserId,
 };
 
@@ -95,7 +95,7 @@ pub fn from_record(record: &Record<'_>) -> ServiceLogV1 {
 
         let mut stacktrace = String::new();
         for trace in error.backtraces() {
-            writeln!(stacktrace, "{:?}", trace).unwrap();
+            writeln!(stacktrace, "{trace:?}").unwrap();
         }
         message = message.stacktrace(stacktrace);
 

--- a/witchcraft-logging-api/src/lib.rs
+++ b/witchcraft-logging-api/src/lib.rs
@@ -12,7 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #![allow(warnings)]
-include!(concat!(
-    env!("OUT_DIR"),
-    "/witchcraft-logging-api/objects/mod.rs"
-));
+include!(concat!(env!("OUT_DIR"), "/witchcraft-logging-api/mod.rs"));


### PR DESCRIPTION
Just making things a bit more uniform - I don't expect we'd ever add non-object definitions to the logging API but you never now.