### PR TITLE
Very basic WASM logger implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,5 @@ members = [
     "witchcraft-log-util",
     "witchcraft-logging-api",
     "witchcraft-metrics",
+    "witchcraft-wasm-logger",
 ]

--- a/witchcraft-wasm-logger/Cargo.toml
+++ b/witchcraft-wasm-logger/Cargo.toml
@@ -8,8 +8,13 @@ repository = "https://github.com/palantir/witchcraft-rust-logging"
 categories = ["wasm"]
 
 [dependencies]
+chrono = "0.4.42"
 conjure-serde = "5.0.0"
+serde = "1.0.228"
+serde_json = "1.0.145"
+serde-wasm-bindgen = "0.6.5"
 web-sys = {  version = "0.3.81", features = ["console"] }
 witchcraft-log = { version = "5.0.0", path = "../witchcraft-log" }
 witchcraft-log-util = { version = "2.0.0", path = "../witchcraft-log-util" }
+witchcraft-logging-api = { version = "2.0.0", path = "../witchcraft-logging-api" }
 

--- a/witchcraft-wasm-logger/Cargo.toml
+++ b/witchcraft-wasm-logger/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "witchcraft-wasm-logger"
+version = "0.1.0"
+edition = "2024"
+license = "Apache-2.0"
+description = "A Witchcraft logger that sends logs to the browser console"
+repository = "https://github.com/palantir/witchcraft-rust-logging"
+categories = ["wasm"]
+
+[dependencies]
+conjure-serde = "5.0.0"
+web-sys = {  version = "0.3.81", features = ["console"] }
+witchcraft-log = { version = "5.0.0", path = "../witchcraft-log" }
+witchcraft-log-util = { version = "2.0.0", path = "../witchcraft-log-util" }
+

--- a/witchcraft-wasm-logger/src/lib.rs
+++ b/witchcraft-wasm-logger/src/lib.rs
@@ -29,10 +29,13 @@
 //!
 #![warn(missing_docs)]
 
-use conjure_serde::json;
+use chrono::SecondsFormat;
+use serde::Serialize;
 use web_sys::console;
 use witchcraft_log::{Level, LevelFilter, Log, Metadata, Record, SetLoggerError};
 use witchcraft_log_util::{filter::Filter, service};
+use witchcraft_logging_api::objects::ServiceLogV1;
+
 struct Logger {
     filter: Filter,
 }
@@ -48,16 +51,23 @@ impl Log for Logger {
         }
 
         let console_log = match record.level() {
-            Level::Error | Level::Fatal => console::error_1,
-            Level::Warn => console::warn_1,
-            Level::Info => console::info_1,
-            Level::Debug => console::log_1,
-            Level::Trace => console::debug_1,
+            Level::Error | Level::Fatal => console::error_2,
+            Level::Warn => console::warn_2,
+            Level::Info => console::info_2,
+            Level::Debug => console::log_2,
+            Level::Trace => console::debug_2,
         };
 
         let service_log = service::from_record(record);
-        let buf = json::to_string(&service_log).unwrap();
-        console_log(&buf.into());
+        let message = slslog(&service_log, record);
+        let full_record = serde_wasm_bindgen::to_value(&service_log).unwrap();
+
+        console_log(&message.into(), &full_record);
+
+        // For errors and warns, at least get a stacktrace from where the log is coming from.
+        if record.level() == Level::Error || record.level() == Level::Warn {
+            console::trace_0(); // this logs the current stacktrace to console
+        }
     }
 
     fn flush(&self) {}
@@ -78,4 +88,55 @@ pub fn try_init(filter: Filter) -> Result<(), SetLoggerError> {
 pub fn try_init_with_level(level: LevelFilter) -> Result<(), SetLoggerError> {
     let filter = Filter::builder().level(level).build();
     try_init(filter)
+}
+
+// This mostly approximates what the slslog binary outputs
+fn slslog(service_log: &ServiceLogV1, original_log: &Record<'_>) -> String {
+    let mut msg = format!(
+        "{:<5} [{}] {}: {} (file: {}, line: {})",
+        service_log.level(),
+        service_log
+            .time()
+            .to_rfc3339_opts(SecondsFormat::Millis, true),
+        service_log.origin().unwrap_or(""),
+        service_log.message(),
+        original_log.file().unwrap_or(""),
+        original_log.line().unwrap_or(0),
+    );
+
+    msg += get_params(service_log.params().iter(), true).as_str();
+    msg += get_params(service_log.unsafe_params().iter(), true).as_str();
+
+    msg
+}
+
+fn get_params<'a, T: Serialize + 'a, M: Iterator<Item = (&'a String, &'a T)>>(
+    params: M,
+    prefix_first: bool,
+) -> String {
+    let mut msg: String = String::new();
+    let mut first = true;
+    for (name, value) in params {
+        if "file" == name || "line" == name {
+            // Already printed in a specific format above
+            continue;
+        }
+        if !first || prefix_first {
+            msg += ", ";
+        }
+        first = false;
+        msg += name.as_str();
+        msg += ": ";
+
+        let serialized_value = serde_json::to_value(value).unwrap();
+        if serialized_value.is_object() {
+            let obj = serialized_value.as_object().unwrap();
+            msg += " map[";
+            msg += get_params(obj.iter(), false).as_str();
+            msg += "]";
+        } else {
+            msg += serde_json::to_string(&serialized_value).unwrap().as_str();
+        }
+    }
+    msg
 }

--- a/witchcraft-wasm-logger/src/lib.rs
+++ b/witchcraft-wasm-logger/src/lib.rs
@@ -63,6 +63,8 @@ impl Log for Logger {
     fn flush(&self) {}
 }
 
+/// Initializes the WASM environment with this logger and provided filter. Logger can only be
+/// initialized once; else, an error is returned.
 pub fn try_init(filter: Filter) -> Result<(), SetLoggerError> {
     let max_level = filter.max_level();
     witchcraft_log::set_boxed_logger(Box::new(Logger { filter }))?;
@@ -71,6 +73,8 @@ pub fn try_init(filter: Filter) -> Result<(), SetLoggerError> {
     Ok(())
 }
 
+/// Initializes the WASM environment with this logger and a global maximum log level. Logger can
+/// only be initialized once; else, an error is returned.
 pub fn try_init_with_level(level: LevelFilter) -> Result<(), SetLoggerError> {
     let filter = Filter::builder().level(level).build();
     try_init(filter)

--- a/witchcraft-wasm-logger/src/lib.rs
+++ b/witchcraft-wasm-logger/src/lib.rs
@@ -13,8 +13,22 @@
 // limitations under the License.
 //! A simple Witchcraft logger that can be used in a WebAssembly to log messages to browser console.
 //!
+//! Witchcraft log levels are mapped to console functions as follows:
+//!
+//! | Witchcraft| Web Console       |
+//! |------------|-------------------|
+//! | `trace!()` | `console.debug()` |
+//! | `debug!()` | `console.log()`   |
+//! | `info!()`  | `console.info()`  |
+//! | `warn!()`  | `console.warn()`  |
+//! | `error!()` | `console.error()` |
+//!
+//! This mapping is similar to the [console_log crate](https://crates.io/crates/console_log).
+//!
 //! Logs are written to standard error in the standard Witchcraft `service.1` JSON format.
 //!
+#![warn(missing_docs)]
+
 use conjure_serde::json;
 use web_sys::console;
 use witchcraft_log::{Level, LevelFilter, Log, Metadata, Record, SetLoggerError};
@@ -37,8 +51,8 @@ impl Log for Logger {
             Level::Error | Level::Fatal => console::error_1,
             Level::Warn => console::warn_1,
             Level::Info => console::info_1,
-            Level::Debug => console::debug_1,
-            Level::Trace => console::trace_1,
+            Level::Debug => console::log_1,
+            Level::Trace => console::debug_1,
         };
 
         let service_log = service::from_record(record);

--- a/witchcraft-wasm-logger/src/lib.rs
+++ b/witchcraft-wasm-logger/src/lib.rs
@@ -1,0 +1,63 @@
+// Copyright 2025 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//! A simple Witchcraft logger that can be used in a WebAssembly to log messages to browser console.
+//!
+//! Logs are written to standard error in the standard Witchcraft `service.1` JSON format.
+//!
+use conjure_serde::json;
+use web_sys::console;
+use witchcraft_log::{Level, LevelFilter, Log, Metadata, Record, SetLoggerError};
+use witchcraft_log_util::{filter::Filter, service};
+struct Logger {
+    filter: Filter,
+}
+
+impl Log for Logger {
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+        self.filter.enabled(metadata)
+    }
+
+    fn log(&self, record: &Record<'_>) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+
+        let console_log = match record.level() {
+            Level::Error | Level::Fatal => console::error_1,
+            Level::Warn => console::warn_1,
+            Level::Info => console::info_1,
+            Level::Debug => console::debug_1,
+            Level::Trace => console::trace_1,
+        };
+
+        let service_log = service::from_record(record);
+        let buf = json::to_string(&service_log).unwrap();
+        console_log(&buf.into());
+    }
+
+    fn flush(&self) {}
+}
+
+pub fn try_init(filter: Filter) -> Result<(), SetLoggerError> {
+    let max_level = filter.max_level();
+    witchcraft_log::set_boxed_logger(Box::new(Logger { filter }))?;
+    witchcraft_log::set_max_level(max_level);
+
+    Ok(())
+}
+
+pub fn try_init_with_level(level: LevelFilter) -> Result<(), SetLoggerError> {
+    let filter = Filter::builder().level(level).build();
+    try_init(filter)
+}


### PR DESCRIPTION
==COMMIT_MSG==
A basic logger implementation for WASM target environment. Dumps logs to browser console in json format.
==COMMIT_MSG==

